### PR TITLE
Proposed Solution for Issue #2

### DIFF
--- a/IndianPines_DataSet_Preparation_Without_Augmentation.ipynb
+++ b/IndianPines_DataSet_Preparation_Without_Augmentation.ipynb
@@ -197,7 +197,7 @@
     "for i in range(HEIGHT - PATCH_SIZE + 1):\n",
     "    for j in range(WIDTH - PATCH_SIZE + 1):\n",
     "        curr_inp = Patch(i,j)\n",
-    "        curr_tar = target_mat[i + (PATCH_SIZE - 1)/2, j + (PATCH_SIZE - 1)/2]\n",
+    "        curr_tar = target_mat[i + int((PATCH_SIZE - 1)/2), j + int((PATCH_SIZE - 1)/2)]\n",
     "        if(curr_tar!=0): #Ignore patches with unknown landcover type for the central pixel\n",
     "            CLASSES[curr_tar-1].append(curr_inp)"
    ]


### PR DESCRIPTION
I faced the same error while using the project. Thanks to @ishiry for mentioning it in [Issue 2](https://github.com/KGPML/Hyperspectral/issues/2)
The error occurs because default devision in python outputs a float. At line number 6 in In[8] `curr_tar = target_mat[i + (PATCH_SIZE - 1)/2, j + (PATCH_SIZE - 1)/2]` the division by 2 operation creates a float output which is not accepted by `target_mat[]` variable because it needs integer as indexes. 
I have rectified the issue by adding explicit type conversion for the float output to integer by making the line `curr_tar = target_mat[i + int((PATCH_SIZE - 1)/2), j + int((PATCH_SIZE - 1)/2)]\n`
After making the change, the code is running fine on my machine

@Project-Admin please review the changes and accept the PR if it is correct.